### PR TITLE
Added .NET 5 as a valid target

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,10 +15,14 @@ jobs:
     steps:
     - name: Checkout this repository
       uses: actions/checkout@v2   
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.301
+    - name: Setup .NET Core 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.2
     - name: Install dependencies
       run: dotnet restore
     - name: Build      

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET Core 5.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.2
+          dotnet-version: 5
     - name: Install dependencies
       run: dotnet restore
     - name: Build      

--- a/src/Projektanker.Icons.Avalonia.FontAwesome/Projektanker.Icons.Avalonia.FontAwesome.csproj
+++ b/src/Projektanker.Icons.Avalonia.FontAwesome/Projektanker.Icons.Avalonia.FontAwesome.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Authors>Sebastian Rumohr</Authors>
         <Company>Projektanker GmbH</Company>
         <PackageProjectUrl></PackageProjectUrl>

--- a/src/Projektanker.Icons.Avalonia/Projektanker.Icons.Avalonia.csproj
+++ b/src/Projektanker.Icons.Avalonia/Projektanker.Icons.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Authors>Sebastian Rumohr</Authors>
         <Company>Projektanker GmbH</Company>
         <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
We are building an application with .NET 5, but currently, only .NET Core 3.1 is a valid framework target (which is blocking us).
I haven't seen any issues/breaking changes stemming from this PR.
