### PR TITLE
Removed Avalonia.Desktop dependency

### DIFF
--- a/src/Projektanker.Icons.Avalonia.FontAwesome.Test/Projektanker.Icons.Avalonia.FontAwesome.Test.csproj
+++ b/src/Projektanker.Icons.Avalonia.FontAwesome.Test/Projektanker.Icons.Avalonia.FontAwesome.Test.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Avalonia.Skia" Version="0.10.0" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Projektanker.Icons.Avalonia.MaterialDesign.Test/Projektanker.Icons.Avalonia.MaterialDesign.Test.csproj
+++ b/src/Projektanker.Icons.Avalonia.MaterialDesign.Test/Projektanker.Icons.Avalonia.MaterialDesign.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Skia" Version="0.10.0" />
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Projektanker.Icons.Avalonia/Projektanker.Icons.Avalonia.csproj
+++ b/src/Projektanker.Icons.Avalonia/Projektanker.Icons.Avalonia.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+        <PackageReference Include="Avalonia" Version="0.10.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I don't see a reason why this library should depend on Avalonia.Desktop. Also, with the recent integration of Avalonia for WASM, this makes the debug build a bit large.