### PR TITLE
Use System.Text.Json instead of Newtonsoft

### DIFF
--- a/src/Projektanker.Icons.Avalonia.FontAwesome/FontAwesomeIcon.cs
+++ b/src/Projektanker.Icons.Avalonia.FontAwesome/FontAwesomeIcon.cs
@@ -4,11 +4,12 @@ namespace Projektanker.Icons.Avalonia.FontAwesome
 {
     internal class FontAwesomeIcon
     {
-        public List<Style> Styles { get; set; }
+
+        public Style[] Styles { get; set; }
 
         public string Unicode { get; set; }
 
-        public List<string> Free { get; set; }
+        public string[] Free { get; set; }
 
         public Dictionary<Style, Svg> Svg { get; set; }
     }

--- a/src/Projektanker.Icons.Avalonia.FontAwesome/Projektanker.Icons.Avalonia.FontAwesome.csproj
+++ b/src/Projektanker.Icons.Avalonia.FontAwesome/Projektanker.Icons.Avalonia.FontAwesome.csproj
@@ -8,7 +8,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="System.Text.Json" Version="6.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Feel free to reject this PR.

# What this PR does

**1. Related to FontAwesome only**
2. Remove **Newtonsoft Json** dependency
3. Add **System.Text.Json** dependency
4. Less startup time and more performance

# Why

**System.Text.Json** is maintained by Microsoft and part of .NET.
While it's one dependecy for another, i think going all .NET as possible is better for libraries.
As bonus it offer more performance, here my test:

```C#
private static Dictionary<string, FontAwesomeIcon> Parse()
{
	Assembly assembly = Assembly.GetExecutingAssembly();
	var resourceName = $"{assembly.GetName().Name}.Assets.icons.json";
	using (Stream stream = assembly.GetManifestResourceStream(resourceName))
	{
		Stopwatch sw = Stopwatch.StartNew();
		using (TextReader textReader = new StreamReader(stream))
		{
			using (JsonReader jsonReader = new JsonTextReader(textReader))
			{
				JsonSerializer serializer = JsonSerializer.Create();
				var result = serializer.Deserialize<Dictionary<string, FontAwesomeIcon>>(jsonReader);
				//return result;
				Debug.WriteLine($"Newtonsoft: {sw.ElapsedMilliseconds}ms");

				stream.Position = 0;
				sw.Restart();
				var result2 = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, FontAwesomeIcon>>(stream, 
					new JsonSerializerOptions()
					{
						PropertyNameCaseInsensitive = true,
						Converters = { new JsonStringEnumConverter() }
					});

				Debug.WriteLine($".NET: {sw.ElapsedMilliseconds}ms");
				return result2;
			}
		}
	}
}
```

Result on i9-9900k, Windows 11 (Debug):

```
Newtonsoft: 248ms
.NET: 51ms
```

3.8x less time to parse the json file. While 248ms is not much, the json file will grow more and more, and it's better to have less startup time on applications.

# Extra information

- Tested and working
- I changed `Styles` and `Free`, from `List<>` to `Array[]` to remove the extra overhead of a list (No add nor remove required as they are readonly)

# Resources

- https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-6-0
- https://inspiration.nlogic.ca/en/a-comparison-of-newtonsoft.json-and-system.text.json